### PR TITLE
[feat] #10 - Board CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'

--- a/src/main/java/com/example/coalawebbackend/api/board/controller/BoardController.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/controller/BoardController.java
@@ -1,0 +1,79 @@
+package com.example.coalawebbackend.api.board.controller;
+
+import com.example.coalawebbackend.api.board.dto.BoardResponse;
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.CreateBoardResponse;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardResponse;
+import com.example.coalawebbackend.api.board.facade.BoardFacade;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/boards")
+public class BoardController implements BoardControllerSpec{
+
+    private final BoardFacade boardFacade;
+
+    @PostMapping
+    public ResponseEntity<CreateBoardResponse> createBoard(
+            @Valid @RequestBody CreateBoardRequest request,
+            @AuthenticationPrincipal String userId
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(boardFacade.createBoard(request, userId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BoardResponse>> getBoards(
+            @RequestParam(required = false) Boolean isActive
+    ) {
+        List<BoardResponse> response =
+                boardFacade.getBoards(isActive);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+    }
+
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<UpdateBoardResponse> updateBoard(
+            @PathVariable Long boardId,
+            @Valid @RequestBody UpdateBoardRequest request,
+            @AuthenticationPrincipal String userId
+    ) {
+        UpdateBoardResponse response =
+                boardFacade.updateBoard(boardId, request, userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
+
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Void> deleteBoard(
+            @PathVariable Long boardId,
+            @AuthenticationPrincipal String userId
+    ) {
+        boardFacade.deleteBoard(boardId, userId);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/controller/BoardControllerSpec.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/controller/BoardControllerSpec.java
@@ -1,0 +1,71 @@
+package com.example.coalawebbackend.api.board.controller;
+
+import com.example.coalawebbackend.api.board.dto.BoardResponse;
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.CreateBoardResponse;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Board API", description = "게시판 관련 API")
+public interface BoardControllerSpec {
+
+    @Operation(summary = "게시판 생성", description = "새로운 게시판을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시판 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CreateBoardResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    ResponseEntity<CreateBoardResponse> createBoard(
+            @Valid @RequestBody CreateBoardRequest request,
+            String userId
+    );
+
+    @Operation(summary = "게시판 목록 조회", description = "게시판 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(array = @ArraySchema(
+                            schema = @Schema(implementation = BoardResponse.class))))
+    })
+    ResponseEntity<List<BoardResponse>> getBoards(
+            @RequestParam(required = false) Boolean isActive
+    );
+
+    @Operation(summary = "게시판 수정", description = "게시판 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = UpdateBoardResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "게시판을 찾을 수 없음")
+    })
+    ResponseEntity<UpdateBoardResponse> updateBoard(
+            @PathVariable Long boardId,
+            @Valid @RequestBody UpdateBoardRequest request,
+            String userId
+    );
+
+    @Operation(summary = "게시판 삭제", description = "게시판을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "게시판을 찾을 수 없음")
+    })
+    ResponseEntity<Void> deleteBoard(
+            @PathVariable Long boardId,
+            String userId
+    );
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/BoardResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/BoardResponse.java
@@ -1,0 +1,35 @@
+package com.example.coalawebbackend.api.board.dto;
+
+import com.example.coalawebbackend.domain.board.entity.Board;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardResponse {
+
+    private Long boardId;
+    private String boardName;
+    private String boardType;
+    private String description;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    public static BoardResponse from(Board board) {
+        return BoardResponse.builder()
+                .boardId(board.getBoardId())
+                .boardName(board.getName())
+                .boardType(board.getType())
+                .description(board.getDescription())
+                .isActive(board.getIsActive())
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardRequest.java
@@ -1,0 +1,27 @@
+package com.example.coalawebbackend.api.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateBoardRequest {
+
+    @NotBlank(message = "게시판 이름은 필수입니다.")
+    @Size(max = 50, message = "게시판 이름은 50자 이내여야 합니다.")
+    private String boardName;
+
+    @NotBlank(message = "게시판 타입은 필수입니다.")
+    @Pattern(regexp = "NORMAL|RECRUIT", message = "게시판 타입은 NORMAL 또는 RECRUIT만 가능합니다.")
+    private String boardType;
+
+    @Size(max = 255, message = "설명은 255자 이내여야 합니다.")
+    private String description;
+
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardRequest.java
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateBoardRequest {
 
@@ -23,5 +25,6 @@ public class CreateBoardRequest {
 
     @Size(max = 255, message = "설명은 255자 이내여야 합니다.")
     private String description;
+
 
 }

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/CreateBoardResponse.java
@@ -1,0 +1,24 @@
+package com.example.coalawebbackend.api.board.dto;
+
+import com.example.coalawebbackend.domain.board.entity.Board;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CreateBoardResponse {
+
+    private Long boardId;
+    private String boardName;
+    private LocalDateTime createdAt;
+
+    public static CreateBoardResponse from(Board board) {
+        return new CreateBoardResponse(
+                board.getBoardId(),
+                board.getName(),
+                board.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/UpdateBoardRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/UpdateBoardRequest.java
@@ -1,0 +1,23 @@
+package com.example.coalawebbackend.api.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateBoardRequest {
+
+    @NotBlank(message = "게시판 이름은 필수입니다.")
+    @Size(max = 50, message = "게시판 이름은 50자 이내여야 합니다.")
+    private String boardName;
+
+    @Size(max = 255, message = "설명은 255자 이내여야 합니다.")
+    private String description;
+
+    private Boolean isActive;
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/dto/UpdateBoardResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/dto/UpdateBoardResponse.java
@@ -1,0 +1,17 @@
+package com.example.coalawebbackend.api.board.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class UpdateBoardResponse {
+
+    private Long boardId;
+    private String status;
+
+    public static UpdateBoardResponse of(Long boardId) {
+        return new UpdateBoardResponse(boardId, "UPDATED");
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/board/facade/BoardFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/facade/BoardFacade.java
@@ -1,0 +1,44 @@
+package com.example.coalawebbackend.api.board.facade;
+
+import com.example.coalawebbackend.api.board.dto.BoardResponse;
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.CreateBoardResponse;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardResponse;
+import com.example.coalawebbackend.domain.board.service.BoardService;
+import com.example.coalawebbackend.domain.user.entity.User;
+import com.example.coalawebbackend.domain.user.service.UserService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardFacade {
+
+    private final UserService userService;
+    private final BoardService boardService;
+
+    @Transactional
+    public CreateBoardResponse createBoard(CreateBoardRequest request, String userId) {
+        User user = userService.findById(userId);
+        return boardService.createBoard(request, user);
+    }
+
+    public List<BoardResponse> getBoards(Boolean isActive) {
+        return boardService.getBoards(isActive);
+    }
+
+    @Transactional
+    public UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, String userId) {
+        User user = userService.findById(userId);
+        return boardService.updateBoard(boardId, request, user);
+    }
+
+    @Transactional
+    public void deleteBoard(Long boardId, String userId) {
+        User user = userService.findById(userId);
+        boardService.deleteBoard(boardId, user);
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -15,10 +15,12 @@ public enum ErrorCode implements BaseCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 리프레시 토큰입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "잘못된 사용자 ID 형식입니다."),
 
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판을 찾을 수 없습니다."),
     BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 게시판에 대한 권한이 없습니다."),
     BOARD_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 게시판입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -14,7 +14,11 @@ public enum ErrorCode implements BaseCode {
 
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 리프레시 토큰입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판을 찾을 수 없습니다."),
+    BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 게시판에 대한 권한이 없습니다."),
+    BOARD_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 게시판입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
@@ -1,0 +1,73 @@
+package com.example.coalawebbackend.domain.board.entity;
+
+
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.common.entity.BaseEntity;
+import com.example.coalawebbackend.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "boards")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Board extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long boardId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String type = "NORMAL";
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    private String description;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.isActive == null) {
+            this.isActive = true;
+        }
+    }
+
+    public void updateBoard(UpdateBoardRequest request) {
+        this.name = request.getBoardName();
+        this.description = request.getDescription();
+        this.isActive = request.getIsActive();
+    }
+
+    public static Board createFromBoard(CreateBoardRequest req, User user) {
+        return Board.builder()
+                .user(user)
+                .name(req.getBoardName())
+                .type(req.getBoardType())
+                .description(req.getDescription())
+                .isActive(true)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,6 +39,7 @@ public class Board extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     @Builder.Default
     private String type = "NORMAL";
 
@@ -65,7 +67,7 @@ public class Board extends BaseEntity {
         return Board.builder()
                 .name(name)
                 .description(description)
-                .type(type)
+                .type(Objects.requireNonNullElse(type, "NORMAL"))
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/entity/Board.java
@@ -1,8 +1,6 @@
 package com.example.coalawebbackend.domain.board.entity;
 
 
-import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
-import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
 import com.example.coalawebbackend.common.entity.BaseEntity;
 import com.example.coalawebbackend.domain.user.entity.User;
 import jakarta.persistence.Column;
@@ -40,10 +38,10 @@ public class Board extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Builder.Default
     private String type = "NORMAL";
 
-    @Column(nullable = false)
+    @Builder.Default
     private Boolean isActive = true;
 
     private String description;
@@ -55,19 +53,20 @@ public class Board extends BaseEntity {
         }
     }
 
-    public void updateBoard(UpdateBoardRequest request) {
-        this.name = request.getBoardName();
-        this.description = request.getDescription();
-        this.isActive = request.getIsActive();
+    public void updateBoard(String name, String description, Boolean isActive) {
+        this.name = name;
+        this.description = description;
+        if (isActive != null) {
+            this.isActive = isActive;
+        }
     }
 
-    public static Board createFromBoard(CreateBoardRequest req, User user) {
+    public static Board createFromBoard(String name, String description, String type, User user) {
         return Board.builder()
+                .name(name)
+                .description(description)
+                .type(type)
                 .user(user)
-                .name(req.getBoardName())
-                .type(req.getBoardType())
-                .description(req.getDescription())
-                .isActive(true)
                 .build();
     }
 }

--- a/src/main/java/com/example/coalawebbackend/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/repository/BoardRepository.java
@@ -1,0 +1,19 @@
+package com.example.coalawebbackend.domain.board.repository;
+
+import com.example.coalawebbackend.domain.board.entity.Board;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+
+    @Query("""
+    SELECT b
+    FROM Board b
+    WHERE (:isActive IS NULL OR b.isActive = :isActive)
+""")
+    List<Board> findByIsActiveCondition(@Param("isActive") Boolean isActive);
+
+}

--- a/src/main/java/com/example/coalawebbackend/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/service/BoardService.java
@@ -1,0 +1,63 @@
+package com.example.coalawebbackend.domain.board.service;
+
+import com.example.coalawebbackend.api.board.dto.BoardResponse;
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.CreateBoardResponse;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardResponse;
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
+import com.example.coalawebbackend.domain.board.entity.Board;
+import com.example.coalawebbackend.domain.board.repository.BoardRepository;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public CreateBoardResponse createBoard(CreateBoardRequest request, User user) {
+        Board board = Board.createFromBoard(request, user);
+        Board savedBoard = boardRepository.save(board);
+        return CreateBoardResponse.from(savedBoard);
+    }
+
+
+    public List<BoardResponse> getBoards(Boolean isActive) {
+        return boardRepository.findByIsActiveCondition(isActive)
+                .stream()
+                .map(BoardResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public UpdateBoardResponse updateBoard(Long boardId, UpdateBoardRequest request, User user) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+        if (!board.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.BOARD_ACCESS_DENIED);
+        }
+
+        board.updateBoard(request);
+        return UpdateBoardResponse.of(boardId);
+    }
+
+    @Transactional
+    public void deleteBoard(Long boardId, User user) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+        if (!board.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.BOARD_ACCESS_DENIED);
+        }
+
+        boardRepository.delete(board);
+    }
+
+}

--- a/src/main/java/com/example/coalawebbackend/domain/board/service/BoardService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/board/service/BoardService.java
@@ -24,7 +24,7 @@ public class BoardService {
 
     @Transactional
     public CreateBoardResponse createBoard(CreateBoardRequest request, User user) {
-        Board board = Board.createFromBoard(request, user);
+        Board board = Board.createFromBoard(request.getBoardName(), request.getDescription(), request.getBoardType(), user);
         Board savedBoard = boardRepository.save(board);
         return CreateBoardResponse.from(savedBoard);
     }
@@ -45,7 +45,7 @@ public class BoardService {
             throw new CustomException(ErrorCode.BOARD_ACCESS_DENIED);
         }
 
-        board.updateBoard(request);
+        board.updateBoard(request.getBoardName(), request.getDescription(), request.getIsActive());
         return UpdateBoardResponse.of(boardId);
     }
 

--- a/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
@@ -21,7 +21,11 @@ public class UserService {
     }
 
     public User findById(String userId) {
-        return userRepository.findById(Long.parseLong(userId))
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        try {
+            return userRepository.findById(Long.parseLong(userId))
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.INVALID_USER_ID);
+        }
     }
 }

--- a/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.coalawebbackend.domain.user.service;
 
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
 import com.example.coalawebbackend.domain.user.entity.User;
 import com.example.coalawebbackend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +18,10 @@ public class UserService {
     @Transactional
     public User createUser(User user) {
         return userRepository.save(user);
+    }
+
+    public User findById(String userId) {
+        return userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/test/java/com/example/coalawebbackend/board/BoardServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/board/BoardServiceTest.java
@@ -89,7 +89,8 @@ class BoardServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        then(board).should(times(1)).updateBoard(request);
+        then(board).should(times(1)).updateBoard(request.getBoardName(),request.getDescription(),
+                request.getIsActive());
     }
 
     @Test

--- a/src/test/java/com/example/coalawebbackend/board/BoardServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/board/BoardServiceTest.java
@@ -1,0 +1,175 @@
+package com.example.coalawebbackend.board;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+
+import com.example.coalawebbackend.api.board.dto.BoardResponse;
+import com.example.coalawebbackend.api.board.dto.CreateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.CreateBoardResponse;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardRequest;
+import com.example.coalawebbackend.api.board.dto.UpdateBoardResponse;
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
+import com.example.coalawebbackend.domain.board.entity.Board;
+import com.example.coalawebbackend.domain.board.repository.BoardRepository;
+import com.example.coalawebbackend.domain.board.service.BoardService;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    @InjectMocks
+    private BoardService boardService;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("게시글 생성 성공")
+    void createBoard_success() {
+        // given
+        User user = mock(User.class);
+        CreateBoardRequest request = mock(CreateBoardRequest.class);
+        Board board = mock(Board.class);
+
+        given(boardRepository.save(any(Board.class))).willReturn(board);
+
+        // when
+        CreateBoardResponse response = boardService.createBoard(request, user);
+
+        // then
+        assertThat(response).isNotNull();
+        then(boardRepository).should(times(1)).save(any(Board.class));
+    }
+
+    @Test
+    @DisplayName("게시글 목록 조회 성공")
+    void getBoards_success() {
+        // given
+        Board board = mock(Board.class);
+        given(boardRepository.findByIsActiveCondition(true)).willReturn(List.of(board));
+
+        // when
+        List<BoardResponse> result = boardService.getBoards(true);
+
+        // then
+        assertThat(result).hasSize(1);
+        then(boardRepository).should(times(1)).findByIsActiveCondition(true);
+    }
+    @Test
+    @DisplayName("게시글 수정 성공")
+    void updateBoard_success() {
+        // given
+        Long boardId = 1L;
+        User user = mock(User.class);
+        User boardOwner = mock(User.class);
+        Board board = mock(Board.class);
+        UpdateBoardRequest request = mock(UpdateBoardRequest.class);
+
+        given(user.getId()).willReturn(1L);
+        given(boardOwner.getId()).willReturn(1L);  // 같은 ID
+        given(board.getUser()).willReturn(boardOwner);
+        given(boardRepository.findById(boardId)).willReturn(Optional.of(board));
+
+        // when
+        UpdateBoardResponse response = boardService.updateBoard(boardId, request, user);
+
+        // then
+        assertThat(response).isNotNull();
+        then(board).should(times(1)).updateBoard(request);
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 게시글 없음")
+    void updateBoard_fail_boardNotFound() {
+        // given
+        Long boardId = 1L;
+        User user = mock(User.class);
+        UpdateBoardRequest request = mock(UpdateBoardRequest.class);
+
+        given(boardRepository.findById(boardId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> boardService.updateBoard(boardId, request, user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.BOARD_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 작성자 불일치")
+    void updateBoard_fail_accessDenied() {
+        // given
+        Long boardId = 1L;
+        User owner = mock(User.class);
+        User other = mock(User.class);
+        Board board = mock(Board.class);
+        UpdateBoardRequest request = mock(UpdateBoardRequest.class);
+
+        given(owner.getId()).willReturn(1L);
+        given(other.getId()).willReturn(2L);
+        given(board.getUser()).willReturn(owner);
+        given(boardRepository.findById(boardId)).willReturn(Optional.of(board));
+
+        // when & then
+        assertThatThrownBy(() -> boardService.updateBoard(boardId, request, other))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.BOARD_ACCESS_DENIED));
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 성공")
+    void deleteBoard_success() {
+        // given
+        Long boardId = 1L;
+        User user = mock(User.class);
+        User boardOwner = mock(User.class);
+        Board board = mock(Board.class);
+
+        given(user.getId()).willReturn(1L);
+        given(boardOwner.getId()).willReturn(1L);  // 같은 ID
+        given(board.getUser()).willReturn(boardOwner);
+        given(boardRepository.findById(boardId)).willReturn(Optional.of(board));
+
+        // when
+        boardService.deleteBoard(boardId, user);
+
+        // then
+        then(boardRepository).should(times(1)).delete(board);
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 실패 - 작성자 불일치")
+    void deleteBoard_fail_accessDenied() {
+        // given
+        Long boardId = 1L;
+        User owner = mock(User.class);
+        User other = mock(User.class);
+        Board board = mock(Board.class);
+
+        given(owner.getId()).willReturn(1L);
+        given(other.getId()).willReturn(2L);
+        given(board.getUser()).willReturn(owner);
+        given(boardRepository.findById(boardId)).willReturn(Optional.of(board));
+
+        // when & then
+        assertThatThrownBy(() -> boardService.deleteBoard(boardId, other))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.BOARD_ACCESS_DENIED));
+    }
+}


### PR DESCRIPTION
## 📌 Summary
Board CRUD 기능 구현 및 단위 테스트 작성

## ✍️ Description
- close: 
- Board 생성 / 조회 / 수정 / 삭제 기능 구현
- BoardService, BoardFacade 레이어 구현
- isActive 기본값 처리를 위한 @PrePersist 적용
- type 필드 필수값 처리 (@Column(nullable = false))
- BoardService 단위 테스트 작성 (성공/실패 케이스)

## 💡 PR Point
- Facade 레이어에서 User 조회 후 Service로 위임하는 구조로 관심사 분리
- type은 필수값.  isActive만 @PrePersist에서 처리

## 📚 Reference 

## 🔥 Test
- BoardServiceTest

<img width="796" height="360" alt="image" src="https://github.com/user-attachments/assets/a8550d50-fab9-48ac-97a5-4bfdfc644c09" />

  - [x] 게시글 생성 성공
  - [x] 게시글 목록 조회 성공
  - [x] 게시글 수정 성공
  - [x] 게시글 수정 실패 - 게시글 없음 (BOARD_NOT_FOUND)
  - [x] 게시글 수정 실패 - 작성자 불일치 (BOARD_ACCESS_DENIED)
  - [x] 게시글 삭제 성공
  - [x] 게시글 삭제 실패 - 작성자 불일치 (BOARD_ACCESS_DENIED)

## 📝 PR Comment
P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시판 관리 REST API 추가: 생성(GET/POST), 조회, 수정(PATCH), 삭제 지원 및 활성화(isActive) 필터링
  * 요청/응답에 게시판 정보와 생성/수정 타임스탬프 포함
  * 소유자 인증 기반 접근 제어로 권한 검증 적용

* **Bug Fixes**
  * API 오류 상태를 위한 신규 오류 코드 및 명확한 에러 메시지 추가

* **Tests**
  * 게시판 서비스의 생성·조회·수정·삭제 성공 및 오류 경로 단위 테스트 추가

* **Chores**
  * 테스트 라이브러리 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->