### PR TITLE
[feat] #13 - PostLike 토글 기능 구현

### DIFF
--- a/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeController.java
@@ -1,0 +1,27 @@
+package com.example.coalawebbackend.api.postlike.controller;
+
+import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import com.example.coalawebbackend.api.postlike.facade.PostLikeFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/likes")
+public class PostLikeController implements PostLikeControllerSpec {
+
+    private final PostLikeFacade postLikeFacade;
+
+    @PostMapping
+    public ResponseEntity<PostLikeResponse> toggleLike(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal String userId
+    ) {
+        return ResponseEntity.ok(postLikeFacade.toggleLike(postId, userId));
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeControllerSpec.java
+++ b/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeControllerSpec.java
@@ -2,6 +2,7 @@ package com.example.coalawebbackend.api.postlike.controller;
 
 import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -22,6 +23,6 @@ public interface PostLikeControllerSpec {
     })
     ResponseEntity<PostLikeResponse> toggleLike(
             @PathVariable Long postId,
-            String userId
+            @Parameter(hidden = true) String userId
     );
 }

--- a/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeControllerSpec.java
+++ b/src/main/java/com/example/coalawebbackend/api/postlike/controller/PostLikeControllerSpec.java
@@ -1,0 +1,27 @@
+package com.example.coalawebbackend.api.postlike.controller;
+
+import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "PostLike API", description = "게시글 좋아요 관련 API")
+public interface PostLikeControllerSpec {
+
+    @Operation(summary = "게시글 좋아요 토글", description = "좋아요가 없으면 추가, 있으면 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토글 성공",
+                    content = @Content(schema = @Schema(implementation = PostLikeResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    })
+    ResponseEntity<PostLikeResponse> toggleLike(
+            @PathVariable Long postId,
+            String userId
+    );
+}

--- a/src/main/java/com/example/coalawebbackend/api/postlike/dto/PostLikeResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/postlike/dto/PostLikeResponse.java
@@ -1,0 +1,17 @@
+package com.example.coalawebbackend.api.postlike.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostLikeResponse {
+
+    private boolean liked;
+    private long likeCount;
+
+    public static PostLikeResponse of(boolean liked, long likeCount) {
+        return new PostLikeResponse(liked, likeCount);
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/postlike/facade/PostLikeFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/postlike/facade/PostLikeFacade.java
@@ -1,0 +1,25 @@
+package com.example.coalawebbackend.api.postlike.facade;
+
+import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.post.service.PostService;
+import com.example.coalawebbackend.domain.postlike.service.PostLikeService;
+import com.example.coalawebbackend.domain.user.entity.User;
+import com.example.coalawebbackend.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostLikeFacade {
+
+    private final PostLikeService postLikeService;
+    private final PostService postService;
+    private final UserService userService;
+
+    public PostLikeResponse toggleLike(Long postId, String userId) {
+        Post post = postService.getPostById(postId);
+        User user = userService.findById(userId);
+        return postLikeService.toggleLike(user, post);
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -26,8 +26,9 @@ public enum ErrorCode implements BaseCode {
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다." ),
 
-    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다." );
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다." ),
 
+    DUPLICATE_LIKE(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다.");
 
 
 

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode implements BaseCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다." );
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다." ),
+
+    POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다." );
+
+
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/coalawebbackend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/comment/service/CommentService.java
@@ -54,7 +54,7 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
-    private Comment getComment(Long commentId) {
+    public Comment getComment(Long commentId) {
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
     }

--- a/src/main/java/com/example/coalawebbackend/domain/postlike/entity/PostLike.java
+++ b/src/main/java/com/example/coalawebbackend/domain/postlike/entity/PostLike.java
@@ -1,0 +1,51 @@
+package com.example.coalawebbackend.domain.postlike.entity;
+
+import com.example.coalawebbackend.common.entity.BaseEntity;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity
+@Table(
+        name = "post_likes",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PostLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    public static PostLike create(User user, Post post) {
+        return PostLike.builder()
+                .user(user)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/domain/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/postlike/repository/PostLikeRepository.java
@@ -1,0 +1,20 @@
+package com.example.coalawebbackend.domain.postlike.repository;
+
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.postlike.entity.PostLike;
+import com.example.coalawebbackend.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pl FROM PostLike pl WHERE pl.user = :user AND pl.post = :post")
+    Optional<PostLike> findByUserAndPostWithLock(@Param("user") User user, @Param("post") Post post);
+
+    long countByPost(Post post);
+}

--- a/src/main/java/com/example/coalawebbackend/domain/postlike/service/PostLikeService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/postlike/service/PostLikeService.java
@@ -1,12 +1,15 @@
 package com.example.coalawebbackend.domain.postlike.service;
 
 import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
 import com.example.coalawebbackend.domain.post.entity.Post;
 import com.example.coalawebbackend.domain.postlike.entity.PostLike;
 import com.example.coalawebbackend.domain.postlike.repository.PostLikeRepository;
 import com.example.coalawebbackend.domain.user.entity.User;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,8 +29,13 @@ public class PostLikeService {
             long likeCount = postLikeRepository.countByPost(post);
             return PostLikeResponse.of(false, likeCount);
         }
+        // save()는 트랜잭션 종료 시점에 flush돼서 예외가 트랜잭션 밖에 터짐. catch가 안됨.
+        try {
+            postLikeRepository.saveAndFlush(PostLike.create(user, post));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DUPLICATE_LIKE);
+        }
 
-        postLikeRepository.save(PostLike.create(user, post));
         long likeCount = postLikeRepository.countByPost(post);
         return PostLikeResponse.of(true, likeCount);
     }

--- a/src/main/java/com/example/coalawebbackend/domain/postlike/service/PostLikeService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/postlike/service/PostLikeService.java
@@ -1,0 +1,34 @@
+package com.example.coalawebbackend.domain.postlike.service;
+
+import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.postlike.entity.PostLike;
+import com.example.coalawebbackend.domain.postlike.repository.PostLikeRepository;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public PostLikeResponse toggleLike(User user, Post post) {
+        Optional<PostLike> existing = postLikeRepository.findByUserAndPostWithLock(user, post);
+
+        if (existing.isPresent()) {
+            postLikeRepository.delete(existing.get());
+            long likeCount = postLikeRepository.countByPost(post);
+            return PostLikeResponse.of(false, likeCount);
+        }
+
+        postLikeRepository.save(PostLike.create(user, post));
+        long likeCount = postLikeRepository.countByPost(post);
+        return PostLikeResponse.of(true, likeCount);
+    }
+}

--- a/src/test/java/com/example/coalawebbackend/postlike/PostLikeServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/postlike/PostLikeServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.coalawebbackend.postlike;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import com.example.coalawebbackend.api.postlike.dto.PostLikeResponse;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.postlike.entity.PostLike;
+import com.example.coalawebbackend.domain.postlike.repository.PostLikeRepository;
+import com.example.coalawebbackend.domain.postlike.service.PostLikeService;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceTest {
+
+    @InjectMocks
+    private PostLikeService postLikeService;
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
+
+    @Test
+    @DisplayName("좋아요 추가 성공 - 기존 좋아요 없음")
+    void toggleLike_add() {
+        // given
+        User user = mock(User.class);
+        Post post = mock(Post.class);
+
+        given(postLikeRepository.findByUserAndPostWithLock(user, post))
+                .willReturn(Optional.empty());
+        given(postLikeRepository.countByPost(post)).willReturn(1L);
+
+        // when
+        PostLikeResponse response = postLikeService.toggleLike(user, post);
+
+        // then
+        assertThat(response.isLiked()).isTrue();
+        assertThat(response.getLikeCount()).isEqualTo(1L);
+        then(postLikeRepository).should(times(1)).save(any(PostLike.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 성공 - 기존 좋아요 있음")
+    void toggleLike_cancel() {
+        // given
+        User user = mock(User.class);
+        Post post = mock(Post.class);
+        PostLike postLike = mock(PostLike.class);
+
+        given(postLikeRepository.findByUserAndPostWithLock(user, post))
+                .willReturn(Optional.of(postLike));
+        given(postLikeRepository.countByPost(post)).willReturn(0L);
+
+        // when
+        PostLikeResponse response = postLikeService.toggleLike(user, post);
+
+        // then
+        assertThat(response.isLiked()).isFalse();
+        assertThat(response.getLikeCount()).isEqualTo(0L);
+        then(postLikeRepository).should(times(1)).delete(postLike);
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 후 likeCount 정확성 확인")
+    void toggleLike_likeCount() {
+        // given
+        User user = mock(User.class);
+        Post post = mock(Post.class);
+
+        given(postLikeRepository.findByUserAndPostWithLock(user, post))
+                .willReturn(Optional.empty());
+        given(postLikeRepository.countByPost(post)).willReturn(3L);
+
+        // when
+        PostLikeResponse response = postLikeService.toggleLike(user, post);
+
+        // then
+        assertThat(response.getLikeCount()).isEqualTo(3L);
+    }
+}


### PR DESCRIPTION
## 📌 Summary
PostLike 토글 기능 구현 및 테스트 작성
## ✍️ Description
- PostLike 엔티티 및 Repository 생성
- PostLikeService 단위 테스트 작성
- close: 
## 💡 PR Point
- 동시성 문제를 고려해 PESSIMISTIC_WRITE 락을 사용해 findByUserAndPostWithLock으로 구현
- 좋아요 수를 countByPost로 실시간 집계해 낙관적 락 이슈를 방지
-
## 📚 Reference 

## 🔥 Test
PostLikeService 단위 테스트 3개 작성
<img width="812" height="365" alt="image" src="https://github.com/user-attachments/assets/5ad57d4a-0b0e-43bc-9937-c08dcfc5041e" />

- [x] toggleLike 성공 - 좋아요 추가
- [x] toggleLike 성공 - 좋아요 취소
- [x] toggleLike 성공 - likeCount 정확성 확인

## 📝 PR Comment
P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 게시글 좋아요 기능 추가: 사용자가 게시글을 좋아요 하거나 취소할 수 있습니다.
  * 좋아요 개수 실시간 반영: 좋아요 상태 변경 시 개수가 즉시 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->