### PR TITLE
[feat] #29 - Resource CRUD 기능 구현

### DIFF
--- a/src/main/java/com/example/coalawebbackend/api/resource/controller/ResourceController.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/controller/ResourceController.java
@@ -1,0 +1,52 @@
+package com.example.coalawebbackend.api.resource.controller;
+
+import com.example.coalawebbackend.api.resource.dto.CreateResourceRequest;
+import com.example.coalawebbackend.api.resource.dto.ResourceResponse;
+import com.example.coalawebbackend.api.resource.facade.ResourceFacade;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/resources")
+public class ResourceController implements ResourceControllerSpec {
+
+    private final ResourceFacade resourceFacade;
+
+    @PostMapping
+    public ResponseEntity<ResourceResponse> createResource(
+            @PathVariable Long postId,
+            @Valid @RequestBody CreateResourceRequest request,
+            @AuthenticationPrincipal String userId
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(resourceFacade.createResource(postId, request, userId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ResourceResponse>> getResources(
+            @PathVariable Long postId
+    ) {
+        return ResponseEntity.ok(resourceFacade.getResources(postId));
+    }
+
+    @DeleteMapping("/{resourceId}")
+    public ResponseEntity<Void> deleteResource(
+            @PathVariable Long resourceId,
+            @AuthenticationPrincipal String userId
+    ) {
+        resourceFacade.deleteResource(resourceId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/resource/controller/ResourceControllerSpec.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/controller/ResourceControllerSpec.java
@@ -1,0 +1,57 @@
+package com.example.coalawebbackend.api.resource.controller;
+
+import com.example.coalawebbackend.api.resource.dto.CreateResourceRequest;
+import com.example.coalawebbackend.api.resource.dto.ResourceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Resource API", description = "자료 관련 API")
+public interface ResourceControllerSpec {
+
+    @Operation(summary = "자료 업로드", description = "게시글에 자료를 업로드합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "업로드 성공",
+                    content = @Content(schema = @Schema(implementation = ResourceResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    })
+    ResponseEntity<ResourceResponse> createResource(
+            @PathVariable Long postId,
+            @Valid @RequestBody CreateResourceRequest request,
+            @Parameter(hidden = true) String userId
+    );
+
+    @Operation(summary = "자료 목록 조회", description = "게시글의 자료 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(array = @ArraySchema(
+                            schema = @Schema(implementation = ResourceResponse.class)))),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    })
+    ResponseEntity<List<ResourceResponse>> getResources(
+            @PathVariable Long postId
+    );
+
+    @Operation(summary = "자료 삭제", description = "자료를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "자료를 찾을 수 없음")
+    })
+    ResponseEntity<Void> deleteResource(
+            @PathVariable Long resourceId,
+            @Parameter(hidden = true) String userId
+    );
+}

--- a/src/main/java/com/example/coalawebbackend/api/resource/dto/CreateResourceRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/dto/CreateResourceRequest.java
@@ -1,0 +1,39 @@
+package com.example.coalawebbackend.api.resource.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "리소스 생성 요청 DTO")
+public class CreateResourceRequest {
+
+    @Schema(description = "파일 이름", example = "algorithm.pdf")
+    @NotBlank(message = "파일 이름은 필수입니다.")
+    @Size(max = 255)
+    private String fileName;
+
+    @Schema(description = "파일 URL", example = "https://example.com/file/algorithm.pdf")
+    @NotBlank(message = "파일 URL은 필수입니다.")
+    private String fileUrl;
+
+    @Schema(description = "파일 타입", example = "PDF")
+    @NotBlank(message = "파일 타입은 필수입니다.")
+    private String fileType;
+
+    @Schema(description = "파일 크기 (byte)", example = "102400")
+    @NotNull(message = "파일 크기는 필수입니다.")
+    @Positive(message = "파일 크기는 0보다 커야 합니다.")
+    private Long fileSize;
+}

--- a/src/main/java/com/example/coalawebbackend/api/resource/dto/ResourceResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/dto/ResourceResponse.java
@@ -1,0 +1,34 @@
+package com.example.coalawebbackend.api.resource.dto;
+
+import com.example.coalawebbackend.domain.resource.entity.Resource;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class ResourceResponse {
+
+    private Long resourceId;
+    private Long postId;
+    private String fileName;
+    private String fileUrl;
+    private String fileType;
+    private Long fileSize;
+    private LocalDateTime createdAt;
+
+    public static ResourceResponse from(Resource resource) {
+        return ResourceResponse.builder()
+                .resourceId(resource.getId())
+                .postId(resource.getPost().getPostId())
+                .fileName(resource.getFileName())
+                .fileUrl(resource.getFileUrl())
+                .fileType(resource.getFileType())
+                .fileSize(resource.getFileSize())
+                .createdAt(resource.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/resource/facade/ResourceFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/facade/ResourceFacade.java
@@ -1,0 +1,38 @@
+package com.example.coalawebbackend.api.resource.facade;
+
+import com.example.coalawebbackend.api.resource.dto.CreateResourceRequest;
+import com.example.coalawebbackend.api.resource.dto.ResourceResponse;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.post.service.PostService;
+import com.example.coalawebbackend.domain.resource.service.ResourceService;
+import com.example.coalawebbackend.domain.user.entity.User;
+import com.example.coalawebbackend.domain.user.service.UserService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResourceFacade {
+
+    private final ResourceService resourceService;
+    private final PostService postService;
+    private final UserService userService;
+
+    public ResourceResponse createResource(Long postId, CreateResourceRequest request, String userId) {
+        User user = userService.findById(userId);
+        Post post = postService.getPostById(postId);
+
+        return resourceService.createResource(post, user, request);
+    }
+
+    public List<ResourceResponse> getResources(Long postId) {
+        Post post = postService.getPostById(postId);
+        return resourceService.getResources(post);
+    }
+
+    public void deleteResource(Long resourceId, String userId) {
+        User user = userService.findById(userId);
+        resourceService.deleteResource(resourceId, user);
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -28,9 +28,9 @@ public enum ErrorCode implements BaseCode {
 
     POST_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다." ),
 
-    DUPLICATE_LIKE(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다.");
+    DUPLICATE_LIKE(HttpStatus.CONFLICT, "이미 좋아요를 누른 게시글입니다."),
 
-
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/coalawebbackend/domain/resource/entity/Resource.java
+++ b/src/main/java/com/example/coalawebbackend/domain/resource/entity/Resource.java
@@ -1,0 +1,63 @@
+package com.example.coalawebbackend.domain.resource.entity;
+
+import com.example.coalawebbackend.common.entity.BaseEntity;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "resources")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Resource extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String fileUrl;
+
+    @Column(nullable = false)
+    private String fileType;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    public static Resource create(Post post, User user, String fileName, String fileUrl, String fileType, Long fileSize) {
+        return Resource.builder()
+                .post(post)
+                .user(user)
+                .fileName(fileName)
+                .fileUrl(fileUrl)
+                .fileType(fileType)
+                .fileSize(fileSize)
+                .build();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/domain/resource/repository/ResourceRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/resource/repository/ResourceRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ResourceRepository extends JpaRepository<Resource, Long> {
 
-    List<Resource> findByPost(Post post);
-
     @Query("SELECT r FROM Resource r " +
             "JOIN FETCH r.user " +
             "JOIN FETCH r.post " +

--- a/src/main/java/com/example/coalawebbackend/domain/resource/repository/ResourceRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/resource/repository/ResourceRepository.java
@@ -1,0 +1,20 @@
+package com.example.coalawebbackend.domain.resource.repository;
+
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.resource.entity.Resource;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+
+    List<Resource> findByPost(Post post);
+
+    @Query("SELECT r FROM Resource r " +
+            "JOIN FETCH r.user " +
+            "JOIN FETCH r.post " +
+            "WHERE r.post = :post")
+    List<Resource> findByPostWithFetch(@Param("post") Post post);
+
+}

--- a/src/main/java/com/example/coalawebbackend/domain/resource/service/ResourceService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/resource/service/ResourceService.java
@@ -1,0 +1,58 @@
+package com.example.coalawebbackend.domain.resource.service;
+
+import com.example.coalawebbackend.api.resource.dto.CreateResourceRequest;
+import com.example.coalawebbackend.api.resource.dto.ResourceResponse;
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.resource.entity.Resource;
+import com.example.coalawebbackend.domain.resource.repository.ResourceRepository;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResourceService {
+
+    private final ResourceRepository resourceRepository;
+
+    @Transactional
+    public ResourceResponse createResource(Post post, User user, CreateResourceRequest request) {
+        if (!post.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+        Resource resource = Resource.create(post, user,
+                request.getFileName(), request.getFileUrl(),
+                request.getFileType(), request.getFileSize());
+        return ResourceResponse.from(resourceRepository.save(resource));
+    }
+
+    public List<ResourceResponse> getResources(Post post) {
+        return resourceRepository. findByPostWithFetch(post)
+                .stream()
+                .map(ResourceResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteResource(Long resourceId, User user) {
+        Resource resource = getResourceById(resourceId);
+        validateResourceOwner(resource, user);
+        resourceRepository.delete(resource);
+    }
+
+    public Resource getResourceById(Long resourceId) {
+        return resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+
+    private void validateResourceOwner(Resource resource, User user) {
+        if (!resource.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/test/java/com/example/coalawebbackend/resource/ResourceServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/resource/ResourceServiceTest.java
@@ -55,12 +55,12 @@ class ResourceServiceTest {
         return mock(Post.class);
     }
 
-    private Resource makeResource(Long id) {
+    private Resource makeResource() {
         Post post = makePost();
-        given(post.getPostId()).willReturn(id);
+        given(post.getPostId()).willReturn(1L);
 
         Resource resource = mock(Resource.class);
-        given(resource.getId()).willReturn(id);
+        given(resource.getId()).willReturn(1L);
         given(resource.getPost()).willReturn(post);  // 추가
         given(resource.getFileName()).willReturn("file.pdf");
         given(resource.getFileUrl()).willReturn("https://example.com/file.pdf");
@@ -94,7 +94,7 @@ class ResourceServiceTest {
             Post post = makePost();
             given(post.getUser()).willReturn(owner);
 
-            Resource saved = makeResource(1L);
+            Resource saved = makeResource();
             given(resourceRepository.save(any(Resource.class))).willReturn(saved);
 
             // when
@@ -136,7 +136,7 @@ class ResourceServiceTest {
         void success() {
             // given
             Post post = makePost();
-            Resource resource = makeResource(1L);
+            Resource resource = makeResource();
 
             given(resourceRepository.findByPostWithFetch(post)).willReturn(List.of(resource));
 

--- a/src/test/java/com/example/coalawebbackend/resource/ResourceServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/resource/ResourceServiceTest.java
@@ -1,0 +1,258 @@
+package com.example.coalawebbackend.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.example.coalawebbackend.api.resource.dto.CreateResourceRequest;
+import com.example.coalawebbackend.api.resource.dto.ResourceResponse;
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
+import com.example.coalawebbackend.domain.post.entity.Post;
+import com.example.coalawebbackend.domain.resource.entity.Resource;
+import com.example.coalawebbackend.domain.resource.repository.ResourceRepository;
+import com.example.coalawebbackend.domain.resource.service.ResourceService;
+import com.example.coalawebbackend.domain.user.entity.AcademicStatus;
+import com.example.coalawebbackend.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceServiceTest {
+
+    @InjectMocks
+    private ResourceService resourceService;
+
+    @Mock
+    private ResourceRepository resourceRepository;
+
+    private User makeUser(Long id) {
+        User user = User.builder()
+                .email("test" + id + "@example.com")
+                .password("password")
+                .name("테스트유저" + id)
+                .department("컴퓨터공학과")
+                .studentId("2024" + id)
+                .academicStatus(AcademicStatus.ENROLLED)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Post makePost() {
+        return mock(Post.class);
+    }
+
+    private Resource makeResource(Long id) {
+        Post post = makePost();
+        given(post.getPostId()).willReturn(id);
+
+        Resource resource = mock(Resource.class);
+        given(resource.getId()).willReturn(id);
+        given(resource.getPost()).willReturn(post);  // 추가
+        given(resource.getFileName()).willReturn("file.pdf");
+        given(resource.getFileUrl()).willReturn("https://example.com/file.pdf");
+        given(resource.getFileType()).willReturn("application/pdf");
+        given(resource.getFileSize()).willReturn(1024L);
+        return resource;
+    }
+
+    // mock 없이 빌더로 생성
+    private CreateResourceRequest makeRequest() {
+        return CreateResourceRequest.builder()
+                .fileName("file.pdf")
+                .fileUrl("https://example.com/file.pdf")
+                .fileType("application/pdf")
+                .fileSize(1024L)
+                .build();
+    }
+
+    // ───────────────────────────────────────────
+    // createResource
+    // ───────────────────────────────────────────
+    @Nested
+    @DisplayName("createResource")
+    class CreateResource {
+
+        @Test
+        @DisplayName("post 작성자가 resource를 생성하면 성공한다")
+        void success() {
+            // given
+            User owner = makeUser(1L);
+            Post post = makePost();
+            given(post.getUser()).willReturn(owner);
+
+            Resource saved = makeResource(1L);
+            given(resourceRepository.save(any(Resource.class))).willReturn(saved);
+
+            // when
+            ResourceResponse response = resourceService.createResource(post, owner, makeRequest());
+
+            // then
+            assertThat(response).isNotNull();
+            then(resourceRepository).should().save(any(Resource.class));
+        }
+
+        @Test
+        @DisplayName("post 작성자가 아닌 사용자가 resource를 생성하면 ACCESS_DENIED 예외가 발생한다")
+        void fail_notOwner() {
+            // given
+            User owner = makeUser(1L);
+            User other = makeUser(2L);
+            Post post = makePost();
+            given(post.getUser()).willReturn(owner);
+
+            // when & then
+            assertThatThrownBy(() -> resourceService.createResource(post, other, makeRequest()))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ACCESS_DENIED));
+
+            then(resourceRepository).should(never()).save(any());
+        }
+    }
+
+    // ───────────────────────────────────────────
+    // getResources
+    // ───────────────────────────────────────────
+    @Nested
+    @DisplayName("getResources")
+    class GetResources {
+
+        @Test
+        @DisplayName("post에 속한 resource 목록을 반환한다")
+        void success() {
+            // given
+            Post post = makePost();
+            Resource resource = makeResource(1L);
+
+            given(resourceRepository.findByPostWithFetch(post)).willReturn(List.of(resource));
+
+            // when
+            List<ResourceResponse> result = resourceService.getResources(post);
+
+            // then
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("resource가 없으면 빈 리스트를 반환한다")
+        void empty() {
+            // given
+            Post post = makePost();
+            given(resourceRepository.findByPostWithFetch(post)).willReturn(List.of());
+
+            // when
+            List<ResourceResponse> result = resourceService.getResources(post);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    // ───────────────────────────────────────────
+    // deleteResource
+    // ───────────────────────────────────────────
+    @Nested
+    @DisplayName("deleteResource")
+    class DeleteResource {
+
+        @Test
+        @DisplayName("resource 소유자가 삭제하면 성공한다")
+        void success() {
+            // given
+            User owner = makeUser(1L);
+            Resource resource = mock(Resource.class);
+            given(resource.getUser()).willReturn(owner);
+            given(resourceRepository.findById(1L)).willReturn(Optional.of(resource));
+
+            // when
+            resourceService.deleteResource(1L, owner);
+
+            // then
+            then(resourceRepository).should().delete(resource);
+        }
+
+        @Test
+        @DisplayName("resource가 존재하지 않으면 RESOURCE_NOT_FOUND 예외가 발생한다")
+        void fail_notFound() {
+            // given
+            User owner = makeUser(1L);
+            given(resourceRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> resourceService.deleteResource(999L, owner))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+
+            then(resourceRepository).should(never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("resource 소유자가 아닌 사용자가 삭제하면 ACCESS_DENIED 예외가 발생한다")
+        void fail_notOwner() {
+            // given
+            User owner = makeUser(1L);
+            User other = makeUser(2L);
+            Resource resource = mock(Resource.class);
+            given(resource.getUser()).willReturn(owner);
+            given(resourceRepository.findById(1L)).willReturn(Optional.of(resource));
+
+            // when & then
+            assertThatThrownBy(() -> resourceService.deleteResource(1L, other))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ACCESS_DENIED));
+
+            then(resourceRepository).should(never()).delete(any());
+        }
+    }
+
+    // ───────────────────────────────────────────
+    // getResourceById
+    // ───────────────────────────────────────────
+    @Nested
+    @DisplayName("getResourceById")
+    class GetResourceById {
+
+        @Test
+        @DisplayName("존재하는 id면 resource를 반환한다")
+        void success() {
+            // given
+            Resource resource = mock(Resource.class);
+            given(resourceRepository.findById(1L)).willReturn(Optional.of(resource));
+
+            // when
+            Resource result = resourceService.getResourceById(1L);
+
+            // then
+            assertThat(result).isEqualTo(resource);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id면 RESOURCE_NOT_FOUND 예외가 발생한다")
+        void fail_notFound() {
+            // given
+            given(resourceRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> resourceService.getResourceById(999L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
Resource CRUD 기능 구현

## ✍️ Description
- close: #29 

구현 목록
- Resource 엔티티 생성
- Resource 레포지토리 생성
- Resource 서비스 구현 (생성 / 조회 / 삭제)
- Resource Facade 구현
- Resource 컨트롤러 구현

## 💡 PR Point
- Facade 패턴을 활용해 Controller는 요청/응답만 담당하고, 권한 검증 및 비즈니스 조합 로직은 Service로 위엄
- `validateResourceOwner`에서 `post.getUser()` 대신 `resource.getUser()`로 소유자를 검증해 실제 Resource 작성자 기준으로 권한을 확인
- `findByPostWithFetch`에 fetch join을 적용해 N+1 문제를 방지

## 📚 Reference
- 없음

## 🔥 Test
- `ResourceServiceTest` 단위 테스트 작성

<img width="1838" height="504" alt="image" src="https://github.com/user-attachments/assets/297796ea-d1b7-4793-a408-65a21b099cce" />

  - [x]  createResource: 성공 / 권한 없음
  - [x] getResources: 목록 반환 / 빈 목록
  - [x]  deleteResource: 성공 / 리소스 없음 / 권한 없음
  - [x]  getResourceById: 성공 / 리소스 없음

## 📝 PR Comment
P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물에 리소스를 추가, 조회, 삭제할 수 있는 리소스 관리 기능 추가
  * 리소스 소유권 검증 및 접근 제어를 통한 보안 강화
  * 파일명, URL, 유형, 크기 등 리소스 메타데이터 지원

* **테스트**
  * 리소스 생성, 조회, 삭제 작업의 성공/실패 시나리오에 대한 단위 테스트 추가
  * 소유권 검증 및 오류 처리 테스트 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->