### PR TITLE
백엔드 회원 정보와 게시글 응답 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,17 @@ DB_PASSWORD=
 
 # JWT
 JWT_SECRET=
+
+# Spring profile
+SPRING_PROFILES_ACTIVE=prod
+
+# CORS
+APP_CORS_ALLOWED_ORIGINS=https://example.com
+
+# Swagger
+SWAGGER_ENABLED=false
+
+# Redis
+REDIS_URL=127.0.0.1
+REDIS_PORT=6379
+REDIS_PASSWORD=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SERVER_PORT }}
           script: |
+            set -e
             cd /home/ubuntu/coala-web-be-main
             git pull origin main
 
@@ -24,7 +25,9 @@ jobs:
             ./gradlew clean bootJar
 
             if docker compose version >/dev/null 2>&1; then
+              docker rm -f coala-web-be-main 2>/dev/null || true
               docker compose up -d --build
             else
+              docker rm -f coala-web-be-main 2>/dev/null || true
               docker-compose up -d --build
             fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,18 @@
 version: "3.8"
 services:
-  swagger-server:
+  coala-web-be-main:
     build: .
-    container_name: swagger-server
+    container_name: coala-web-be-main
     ports:
       - "80:8080"
     environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
+      APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS}
+      SWAGGER_ENABLED: ${SWAGGER_ENABLED:-false}
       REDIS_URL: ${REDIS_URL}
       REDIS_PORT: ${REDIS_PORT}
       REDIS_PASSWORD: ${REDIS_PASSWORD}

--- a/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
@@ -36,7 +36,7 @@ public class AuthFacade {
         User user =
                 userRepository
                         .findByEmail(request.email())
-                        .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+                        .orElseThrow(() -> new AuthException(ErrorCode.INVALID_CREDENTIALS));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new AuthException(ErrorCode.INVALID_CREDENTIALS);
@@ -71,6 +71,10 @@ public class AuthFacade {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        if (!refreshTokenStore.validate(String.valueOf(userId), request.refreshToken())) {
+            throw new AuthException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
 
         TokenInfo tokens =
                 jwtTokenProvider.generateTokenInfo(

--- a/src/main/java/com/example/coalawebbackend/api/comment/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/comment/dto/CreateCommentRequest.java
@@ -1,6 +1,7 @@
 package com.example.coalawebbackend.api.comment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,5 +13,6 @@ import lombok.NoArgsConstructor;
 public class CreateCommentRequest {
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 1000, message = "댓글 내용은 1000자 이하로 입력해주세요.")
     private String content;
 }

--- a/src/main/java/com/example/coalawebbackend/api/comment/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/comment/dto/UpdateCommentRequest.java
@@ -1,6 +1,7 @@
 package com.example.coalawebbackend.api.comment.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,5 +13,6 @@ import lombok.NoArgsConstructor;
 public class UpdateCommentRequest {
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 1000, message = "댓글 내용은 1000자 이하로 입력해주세요.")
     private String content;
 }

--- a/src/main/java/com/example/coalawebbackend/api/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/post/dto/PostDetailResponse.java
@@ -21,11 +21,17 @@ public class PostDetailResponse {
     private String title;
     private String content;
     private int viewCount;
+    private long commentCount;
+    private long likeCount;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static PostDetailResponse from(Post post) {
+        return from(post, 0, 0);
+    }
+
+    public static PostDetailResponse from(Post post, long commentCount, long likeCount) {
         String nickname = post.getUser().getNickname();
         String displayName = (nickname != null && !nickname.isBlank())
                 ? nickname
@@ -40,6 +46,8 @@ public class PostDetailResponse {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .viewCount(post.getViewCount())
+                .commentCount(commentCount)
+                .likeCount(likeCount)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/coalawebbackend/api/post/dto/PostListResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/post/dto/PostListResponse.java
@@ -20,10 +20,16 @@ public class PostListResponse {
     private String title;
     private String content;
     private int viewCount;
+    private long commentCount;
+    private long likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static PostListResponse from(Post post) {
+        return from(post, 0, 0);
+    }
+
+    public static PostListResponse from(Post post, long commentCount, long likeCount) {
         String nickname = post.getUser().getNickname();
         String displayName = (nickname != null && !nickname.isBlank())
                 ? nickname
@@ -38,6 +44,8 @@ public class PostListResponse {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .viewCount(post.getViewCount())
+                .commentCount(commentCount)
+                .likeCount(likeCount)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/coalawebbackend/api/resource/dto/CreateResourceRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/resource/dto/CreateResourceRequest.java
@@ -3,6 +3,7 @@ package com.example.coalawebbackend.api.resource.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -26,10 +27,13 @@ public class CreateResourceRequest {
 
     @Schema(description = "파일 URL", example = "https://example.com/file/algorithm.pdf")
     @NotBlank(message = "파일 URL은 필수입니다.")
+    @Size(max = 500)
+    @Pattern(regexp = "^https://.+", message = "파일 URL은 https URL이어야 합니다.")
     private String fileUrl;
 
     @Schema(description = "파일 타입", example = "PDF")
     @NotBlank(message = "파일 타입은 필수입니다.")
+    @Size(max = 50)
     private String fileType;
 
     @Schema(description = "파일 크기 (byte)", example = "102400")

--- a/src/main/java/com/example/coalawebbackend/api/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/user/dto/UserCreateRequest.java
@@ -48,12 +48,12 @@ public class UserCreateRequest {
     @Schema(example = "2000-01-01", type = "string", format = "date")
     private LocalDate birthDate;
 
+    @NotNull
     @Schema(example = "MALE", description = "MALE / FEMALE / OTHER / PREFER_NOT_TO_SAY")
     private Gender gender;
 
-    @NotBlank
     @Size(max = 100)
-    @Schema(example = "컴퓨터공학과")
+    @Schema(example = "컴퓨터공학과", description = "기존 호환용 선택 필드")
     private String department;
 
     @NotBlank
@@ -61,10 +61,26 @@ public class UserCreateRequest {
     @Schema(example = "202012345")
     private String studentId;
 
+    @NotNull
     @Min(1)
     @Max(6)
     @Schema(example = "3")
     private Integer grade;
+
+    @NotBlank
+    @Size(max = 39)
+    @Pattern(
+            regexp = "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$",
+            message = "GitHub 아이디 형식이 올바르지 않습니다.")
+    @Schema(example = "coala-dev")
+    private String githubId;
+
+    @Size(max = 255)
+    @Pattern(
+            regexp = "^$|^https://(www\\.)?linkedin\\.com/in/[A-Za-z0-9_-]+/?$",
+            message = "LinkedIn 프로필 URL 형식이 올바르지 않습니다.")
+    @Schema(example = "https://www.linkedin.com/in/coala-dev")
+    private String linkedinUrl;
 
     @NotNull
     @Schema(example = "ENROLLED", description = "ENROLLED / ON_LEAVE / GRADUATED")
@@ -78,10 +94,24 @@ public class UserCreateRequest {
                 .nickname(nickname)
                 .birthDate(birthDate)
                 .gender(gender)
-                .department(department)
+                .department(normalizeDepartment())
                 .studentId(studentId)
                 .grade(grade)
+                .githubId(githubId.trim())
+                .linkedinUrl(normalizeOptional(linkedinUrl))
                 .academicStatus(academicStatus)
                 .build();
+    }
+
+    private String normalizeDepartment() {
+        return department == null || department.isBlank()
+                ? "미입력"
+                : department.trim();
+    }
+
+    private String normalizeOptional(String value) {
+        return value == null || value.isBlank()
+                ? null
+                : value.trim();
     }
 }

--- a/src/main/java/com/example/coalawebbackend/api/user/dto/UserResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/user/dto/UserResponse.java
@@ -27,6 +27,8 @@ public class UserResponse {
     private String department;
     private String studentId;
     private Integer grade;
+    private String githubId;
+    private String linkedinUrl;
     private AcademicStatus academicStatus;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -42,6 +44,8 @@ public class UserResponse {
                 .department(user.getDepartment())
                 .studentId(user.getStudentId())
                 .grade(user.getGrade())
+                .githubId(user.getGithubId())
+                .linkedinUrl(user.getLinkedinUrl())
                 .academicStatus(user.getAcademicStatus())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())

--- a/src/main/java/com/example/coalawebbackend/api/user/facade/UserFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/user/facade/UserFacade.java
@@ -38,6 +38,8 @@ public class UserFacade {
                         .department(user.getDepartment())
                         .studentId(user.getStudentId())
                         .grade(user.getGrade())
+                        .githubId(user.getGithubId())
+                        .linkedinUrl(user.getLinkedinUrl())
                         .academicStatus(user.getAcademicStatus())
                         .build();
         User createdUser = userService.createUser(withEncodedPassword);

--- a/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.example.coalawebbackend.common.config;
 
 import com.example.coalawebbackend.common.jwt.JwtAuthenticationFilter;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -25,32 +27,45 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Value("${app.cors.allowed-origins:http://localhost:3000,http://127.0.0.1:3000}")
+    private String allowedOrigins;
+
+    @Value("${app.security.swagger-enabled:true}")
+    private boolean swaggerEnabled;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.GET,
-                                "/api/boards",
-                                "/api/boards/*",
-                                "/api/boards/*/posts",
-                                "/api/boards/*/posts/*",
-                                "/api/posts/*/comments",
-                                "/api/posts/*/resources"
-                        ).permitAll()
-                        .requestMatchers(
+                .authorizeHttpRequests(auth -> {
+                    auth
+                            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                            .requestMatchers(HttpMethod.GET,
+                                    "/api/boards",
+                                    "/api/boards/*",
+                                    "/api/boards/*/posts",
+                                    "/api/boards/*/posts/*",
+                                    "/api/posts/*/comments",
+                                    "/api/posts/*/resources"
+                            ).permitAll()
+                            .requestMatchers(
+                                    "/api/auth/signup",
+                                    "/api/auth/login",
+                                    "/api/auth/refresh",
+                                    "/api/auth/logout"
+                            ).permitAll();
+
+                    if (swaggerEnabled) {
+                        auth.requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/swagger-ui.html",
-                                "/api/auth/signup",
-                                "/api/auth/login",
-                                "/api/auth/refresh",
-                                "/api/auth/logout"
-                        ).permitAll()
-                        .anyRequest().authenticated()
-                )
+                                "/swagger-ui.html"
+                        ).permitAll();
+                    }
+
+                    auth.anyRequest().authenticated();
+                })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
@@ -60,8 +75,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // TODO: 필요 시 특정 Origin으로 제한
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOrigins(parseAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
@@ -74,5 +88,12 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    private List<String> parseAllowedOrigins() {
+        return Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
     }
 }

--- a/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
+++ b/src/main/java/com/example/coalawebbackend/common/enums/ErrorCode.java
@@ -14,8 +14,13 @@ public enum ErrorCode implements BaseCode {
 
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 리프레시 토큰입니다."),
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "잘못된 사용자 ID 형식입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    DUPLICATE_STUDENT_ID(HttpStatus.CONFLICT, "이미 등록된 학번입니다."),
+    DUPLICATE_GITHUB_ID(HttpStatus.CONFLICT, "이미 등록된 GitHub 아이디입니다."),
+    DUPLICATE_LINKEDIN_URL(HttpStatus.CONFLICT, "이미 등록된 LinkedIn 프로필입니다."),
 
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판을 찾을 수 없습니다."),
     BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 게시판에 대한 권한이 없습니다."),

--- a/src/main/java/com/example/coalawebbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coalawebbackend/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,11 @@
 package com.example.coalawebbackend.common.exception;
 
+import com.example.coalawebbackend.common.enums.ErrorCode;
 import com.example.coalawebbackend.common.response.ApiResponse;
 import com.example.coalawebbackend.common.response.ApiResult;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -12,5 +15,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<ApiResult>> handleApiException(CustomException e) {
         return ApiResponse.onFailure(e.getErrorCode());
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            ConstraintViolationException.class
+    })
+    public ResponseEntity<ApiResponse<ApiResult>> handleValidationException(Exception e) {
+        return ApiResponse.onFailure(ErrorCode.VALIDATION_FAILED);
     }
 }

--- a/src/main/java/com/example/coalawebbackend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/comment/repository/CommentRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPost_PostIdOrderByCreatedAtAsc(Long postId);
+
+    long countByPost_PostId(Long postId);
 }

--- a/src/main/java/com/example/coalawebbackend/domain/post/service/PostService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/post/service/PostService.java
@@ -10,8 +10,10 @@ import com.example.coalawebbackend.common.enums.ErrorCode;
 import com.example.coalawebbackend.common.exception.CustomException;
 import com.example.coalawebbackend.domain.board.entity.Board;
 import com.example.coalawebbackend.domain.board.service.BoardService;
+import com.example.coalawebbackend.domain.comment.repository.CommentRepository;
 import com.example.coalawebbackend.domain.post.entity.Post;
 import com.example.coalawebbackend.domain.post.repository.PostRepository;
+import com.example.coalawebbackend.domain.postlike.repository.PostLikeRepository;
 import com.example.coalawebbackend.domain.user.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,8 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final BoardService boardService;
+    private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public CreatePostResponse createPost(User user, Long boardId, PostRequest request) {
@@ -36,7 +40,7 @@ public class PostService {
     public List<PostListResponse> getPosts(Long boardId) {
         return postRepository.findByBoardBoardId(boardId)
                 .stream()
-                .map(PostListResponse::from)
+                .map(this::toPostListResponse)
                 .toList();
     }
 
@@ -50,7 +54,7 @@ public class PostService {
         postRepository.increaseViewCount(postId);
         Post updatedPost = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        return PostDetailResponse.from(updatedPost);
+        return toPostDetailResponse(updatedPost);
     }
 
     @Transactional
@@ -78,5 +82,19 @@ public class PostService {
         if (!post.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
+    }
+
+    private PostListResponse toPostListResponse(Post post) {
+        return PostListResponse.from(
+                post,
+                commentRepository.countByPost_PostId(post.getPostId()),
+                postLikeRepository.countByPost(post));
+    }
+
+    private PostDetailResponse toPostDetailResponse(Post post) {
+        return PostDetailResponse.from(
+                post,
+                commentRepository.countByPost_PostId(post.getPostId()),
+                postLikeRepository.countByPost(post));
     }
 }

--- a/src/main/java/com/example/coalawebbackend/domain/user/entity/User.java
+++ b/src/main/java/com/example/coalawebbackend/domain/user/entity/User.java
@@ -8,7 +8,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,9 +23,15 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "users",
         uniqueConstraints = {
-                @jakarta.persistence.UniqueConstraint(name = "uk_users_email", columnNames = "email"),
-                @jakarta.persistence.UniqueConstraint(name = "uk_users_student_id", columnNames = "student_id"),
-                @jakarta.persistence.UniqueConstraint(name = "uk_users_nickname", columnNames = "nickname")
+                @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
+                @UniqueConstraint(name = "uk_users_student_id", columnNames = "student_id"),
+                @UniqueConstraint(name = "uk_users_nickname", columnNames = "nickname"),
+                @UniqueConstraint(name = "uk_users_github_id", columnNames = "github_id"),
+                @UniqueConstraint(name = "uk_users_linkedin_url", columnNames = "linkedin_url")
+        },
+        indexes = {
+                @Index(name = "idx_users_academic_status", columnList = "academic_status"),
+                @Index(name = "idx_users_grade", columnList = "grade")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -56,9 +64,13 @@ public class User extends BaseEntity {
     @Column(name = "baekjoon_id", length = 50)
     private String baekjoonId;
 
-    // 선택: GitHub 아이디
-    @Column(name = "github_id", length = 50)
+    // 필수: GitHub 아이디
+    @Column(name = "github_id", nullable = false, length = 39)
     private String githubId;
+
+    // 선택: LinkedIn 프로필 URL
+    @Column(name = "linkedin_url", length = 255)
+    private String linkedinUrl;
 
     // 선택: 생년월일 (LocalDate 로 정규화)
     @Column(name = "birth_date")

--- a/src/main/java/com/example/coalawebbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/coalawebbackend/domain/user/repository/UserRepository.java
@@ -9,4 +9,12 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByStudentId(String studentId);
+
+    boolean existsByGithubId(String githubId);
+
+    boolean existsByLinkedinUrl(String linkedinUrl);
 }

--- a/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
+++ b/src/main/java/com/example/coalawebbackend/domain/user/service/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
 
     @Transactional
     public User createUser(User user) {
+        validateUniqueUser(user);
         return userRepository.save(user);
     }
 
@@ -26,6 +27,24 @@ public class UserService {
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         } catch (NumberFormatException e) {
             throw new CustomException(ErrorCode.INVALID_USER_ID);
+        }
+    }
+
+    private void validateUniqueUser(User user) {
+        if (userRepository.existsByEmail(user.getEmail())) {
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        if (userRepository.existsByStudentId(user.getStudentId())) {
+            throw new CustomException(ErrorCode.DUPLICATE_STUDENT_ID);
+        }
+        if (userRepository.existsByGithubId(user.getGithubId())) {
+            throw new CustomException(ErrorCode.DUPLICATE_GITHUB_ID);
+        }
+        String linkedinUrl = user.getLinkedinUrl();
+        if (linkedinUrl != null
+                && !linkedinUrl.isBlank()
+                && userRepository.existsByLinkedinUrl(linkedinUrl)) {
+            throw new CustomException(ErrorCode.DUPLICATE_LINKEDIN_URL);
         }
     }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+jwt:
+  secret: ${JWT_SECRET}
+
+app:
+  cors:
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
+  security:
+    swagger-enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,10 +11,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: ${JPA_SHOW_SQL:true}
     properties:
       hibernate:
-        format_sql: true
+        format_sql: ${JPA_FORMAT_SQL:true}
 
   data:
     redis:
@@ -26,3 +26,9 @@ jwt:
   secret: ${JWT_SECRET:change-me-dev-only}
   access-token-expiration: 1800000
   refresh-token-expiration: 604800000
+
+app:
+  cors:
+    allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://127.0.0.1:3000}
+  security:
+    swagger-enabled: ${SWAGGER_ENABLED:true}

--- a/src/test/java/com/example/coalawebbackend/post/PostServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/post/PostServiceTest.java
@@ -17,9 +17,11 @@ import com.example.coalawebbackend.common.enums.ErrorCode;
 import com.example.coalawebbackend.common.exception.CustomException;
 import com.example.coalawebbackend.domain.board.entity.Board;
 import com.example.coalawebbackend.domain.board.service.BoardService;
+import com.example.coalawebbackend.domain.comment.repository.CommentRepository;
 import com.example.coalawebbackend.domain.post.entity.Post;
 import com.example.coalawebbackend.domain.post.repository.PostRepository;
 import com.example.coalawebbackend.domain.post.service.PostService;
+import com.example.coalawebbackend.domain.postlike.repository.PostLikeRepository;
 import com.example.coalawebbackend.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +43,12 @@ class PostServiceTest {
 
     @Mock
     private BoardService boardService;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostLikeRepository postLikeRepository;
 
     @Test
     @DisplayName("게시글 생성 성공")
@@ -73,7 +81,10 @@ class PostServiceTest {
 
         given(post.getBoard()).willReturn(board);
         given(post.getUser()).willReturn(user);
+        given(post.getPostId()).willReturn(1L);
         given(postRepository.findByBoardBoardId(1L)).willReturn(List.of(post));
+        given(commentRepository.countByPost_PostId(1L)).willReturn(2L);
+        given(postLikeRepository.countByPost(post)).willReturn(3L);
 
         // when
         List<PostListResponse> result = postService.getPosts(1L);
@@ -95,8 +106,11 @@ class PostServiceTest {
         Post post = mock(Post.class);
 
         given(board.getBoardId()).willReturn(boardId);
+        given(post.getPostId()).willReturn(postId);
         given(post.getBoard()).willReturn(board);
         given(post.getUser()).willReturn(user);
+        given(commentRepository.countByPost_PostId(postId)).willReturn(2L);
+        given(postLikeRepository.countByPost(post)).willReturn(3L);
 
         // when
         given(postRepository.findById(postId)).willReturn(Optional.of(post));

--- a/src/test/java/com/example/coalawebbackend/user/UserServiceTest.java
+++ b/src/test/java/com/example/coalawebbackend/user/UserServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.coalawebbackend.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.example.coalawebbackend.common.enums.ErrorCode;
+import com.example.coalawebbackend.common.exception.CustomException;
+import com.example.coalawebbackend.domain.user.entity.AcademicStatus;
+import com.example.coalawebbackend.domain.user.entity.Gender;
+import com.example.coalawebbackend.domain.user.entity.User;
+import com.example.coalawebbackend.domain.user.repository.UserRepository;
+import com.example.coalawebbackend.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User makeUser() {
+        return User.builder()
+                .email("member@example.com")
+                .password("encoded-password")
+                .name("홍길동")
+                .gender(Gender.MALE)
+                .department("미입력")
+                .studentId("202012345")
+                .grade(3)
+                .githubId("coala-dev")
+                .linkedinUrl("https://www.linkedin.com/in/coala-dev")
+                .academicStatus(AcademicStatus.ENROLLED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원 생성 성공")
+    void createUser_success() {
+        User user = makeUser();
+
+        given(userRepository.save(user)).willReturn(user);
+
+        User created = userService.createUser(user);
+
+        assertThat(created).isEqualTo(user);
+        then(userRepository).should().save(user);
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일이면 회원 생성을 막는다")
+    void createUser_duplicateEmail() {
+        User user = makeUser();
+        given(userRepository.existsByEmail(user.getEmail())).willReturn(true);
+
+        assertThatThrownBy(() -> userService.createUser(user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.DUPLICATE_EMAIL));
+
+        then(userRepository).should(never()).save(user);
+    }
+
+    @Test
+    @DisplayName("이미 등록된 GitHub 아이디면 회원 생성을 막는다")
+    void createUser_duplicateGithubId() {
+        User user = makeUser();
+        given(userRepository.existsByGithubId(user.getGithubId())).willReturn(true);
+
+        assertThatThrownBy(() -> userService.createUser(user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.DUPLICATE_GITHUB_ID));
+
+        then(userRepository).should(never()).save(user);
+    }
+}


### PR DESCRIPTION
스키마 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 GitHub 및 LinkedIn 계정 정보 추가
  * 게시물 목록 및 상세 페이지에 댓글 수 및 좋아요 수 표시

* **버그 수정**
  * 리프레시 토큰 검증 강화로 보안 개선
  * 로그인 실패 시 오류 메시지 표준화

* **기능 개선**
  * 댓글 길이 최대 1000자로 제한
  * 리소스 URL을 HTTPS 필수로 변경
  * 특정 출처에 대한 CORS 설정 추가

* **Chores**
  * 프로덕션 환경 설정 추가
  * Docker 배포 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->