### PR TITLE
Codex/GitHub public activity api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# PostgreSQL (application-dev.yaml과 동일한 변수명)
+# PostgreSQL
 DB_URL=jdbc:postgresql://localhost:5432/coala_web
 DB_USERNAME=postgres
 DB_PASSWORD=
@@ -19,3 +19,7 @@ SWAGGER_ENABLED=false
 REDIS_URL=127.0.0.1
 REDIS_PORT=6379
 REDIS_PASSWORD=
+
+# GitHub public activity lookup
+GITHUB_API_BASE_URL=https://api.github.com
+GITHUB_API_TOKEN=

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/example/coalawebbackend/api/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/auth/dto/LoginRequest.java
@@ -1,19 +1,16 @@
 package com.example.coalawebbackend.api.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-/**
- * 로그인 요청 DTO
- */
 public record LoginRequest(
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Email
-        @Schema(example = "user@example.com")
+        @NotBlank(message = "아이디 또는 이메일은 필수입니다.")
+        @Size(max = 100)
+        @Schema(example = "test")
         String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")
-        @Schema(example = "P@ssw0rd!")
+        @Schema(example = "test1234")
         String password
 ) {}

--- a/src/main/java/com/example/coalawebbackend/api/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/auth/dto/LoginRequest.java
@@ -1,13 +1,15 @@
 package com.example.coalawebbackend.api.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
-        @NotBlank(message = "아이디 또는 이메일은 필수입니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email
         @Size(max = 100)
-        @Schema(example = "test")
+        @Schema(example = "test@test.com")
         String email,
 
         @NotBlank(message = "비밀번호는 필수입니다.")

--- a/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
@@ -12,6 +12,7 @@ import com.example.coalawebbackend.common.jwt.LogoutTokenStore;
 import com.example.coalawebbackend.common.jwt.RefreshTokenStore;
 import com.example.coalawebbackend.domain.user.entity.User;
 import com.example.coalawebbackend.domain.user.repository.UserRepository;
+import io.jsonwebtoken.JwtException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -89,7 +90,13 @@ public class AuthFacade {
 
     @Transactional
     public void logout(String accessToken) {
-        String userId = jwtTokenProvider.getSubject(accessToken);
+        String userId;
+        try {
+            userId = jwtTokenProvider.getSubject(accessToken);
+        } catch (JwtException | IllegalArgumentException e) {
+            return;
+        }
+
         long ttlMillis = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
         logoutTokenStore.add(accessToken, ttlMillis);
         refreshTokenStore.delete(userId);

--- a/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/auth/facade/AuthFacade.java
@@ -34,9 +34,10 @@ public class AuthFacade {
 
     @Transactional
     public TokenResponse login(LoginRequest request) {
+        String email = request.email().trim().toLowerCase();
         User user =
                 userRepository
-                        .findByEmail(request.email())
+                        .findByEmail(email)
                         .orElseThrow(() -> new AuthException(ErrorCode.INVALID_CREDENTIALS));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {

--- a/src/main/java/com/example/coalawebbackend/api/board/controller/BoardController.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/controller/BoardController.java
@@ -51,6 +51,7 @@ public class BoardController implements BoardControllerSpec{
     }
 
     @GetMapping("/{boardId}")
+    @Override
     public ResponseEntity<BoardResponse> getBoard(
             @PathVariable Long boardId
     ) {

--- a/src/main/java/com/example/coalawebbackend/api/board/controller/BoardControllerSpec.java
+++ b/src/main/java/com/example/coalawebbackend/api/board/controller/BoardControllerSpec.java
@@ -45,6 +45,16 @@ public interface BoardControllerSpec {
             @RequestParam(required = false) Boolean isActive
     );
 
+    @Operation(summary = "게시판 단건 조회", description = "게시판 ID로 게시판 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = BoardResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시판을 찾을 수 없음")
+    })
+    ResponseEntity<BoardResponse> getBoard(
+            @PathVariable Long boardId
+    );
+
     @Operation(summary = "게시판 수정", description = "게시판 정보를 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공",

--- a/src/main/java/com/example/coalawebbackend/api/github/controller/GithubActivityController.java
+++ b/src/main/java/com/example/coalawebbackend/api/github/controller/GithubActivityController.java
@@ -1,0 +1,27 @@
+package com.example.coalawebbackend.api.github.controller;
+
+import com.example.coalawebbackend.api.github.dto.GithubActivityResponse;
+import com.example.coalawebbackend.api.github.facade.GithubActivityFacade;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/github")
+public class GithubActivityController {
+
+    private final GithubActivityFacade githubActivityFacade;
+
+    @GetMapping("/public-activity")
+    public ResponseEntity<List<GithubActivityResponse>> getPublicActivity(
+            @RequestParam String username,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(githubActivityFacade.getPublicActivity(username, limit));
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/github/dto/GithubActivityResponse.java
+++ b/src/main/java/com/example/coalawebbackend/api/github/dto/GithubActivityResponse.java
@@ -1,0 +1,22 @@
+package com.example.coalawebbackend.api.github.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GithubActivityResponse {
+
+    private String id;
+    private String type;
+    private String title;
+    private String repository;
+    private String description;
+    private String timeLabel;
+    private String url;
+    private String actor;
+    private String createdAt;
+}

--- a/src/main/java/com/example/coalawebbackend/api/github/facade/GithubActivityFacade.java
+++ b/src/main/java/com/example/coalawebbackend/api/github/facade/GithubActivityFacade.java
@@ -1,0 +1,197 @@
+package com.example.coalawebbackend.api.github.facade;
+
+import com.example.coalawebbackend.api.github.dto.GithubActivityResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class GithubActivityFacade {
+
+    private static final Pattern GITHUB_USERNAME_PATTERN =
+            Pattern.compile("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$");
+    private static final Duration CACHE_TTL = Duration.ofMinutes(5);
+
+    private final RestClient.Builder restClientBuilder;
+    private final Map<String, CachedActivity> activityCache = new ConcurrentHashMap<>();
+
+    @Value("${github.api.base-url:https://api.github.com}")
+    private String githubApiBaseUrl;
+
+    @Value("${github.api.token:}")
+    private String githubApiToken;
+
+    public List<GithubActivityResponse> getPublicActivity(String username, int limit) {
+        if (username == null || !GITHUB_USERNAME_PATTERN.matcher(username).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid GitHub username");
+        }
+
+        int perPage = Math.max(1, Math.min(limit, 30));
+        String cacheKey = username.toLowerCase() + ":" + perPage;
+        CachedActivity cachedActivity = activityCache.get(cacheKey);
+
+        if (cachedActivity != null && cachedActivity.isFresh()) {
+            return cachedActivity.responses();
+        }
+
+        List<GithubActivityResponse> responses = fetchPublicActivity(username, perPage);
+        activityCache.put(cacheKey, new CachedActivity(responses, Instant.now()));
+
+        return responses;
+    }
+
+    private List<GithubActivityResponse> fetchPublicActivity(String username, int perPage) {
+        try {
+            RestClient client = restClientBuilder
+                    .baseUrl(githubApiBaseUrl)
+                    .defaultHeader("Accept", "application/vnd.github+json")
+                    .defaultHeader("X-GitHub-Api-Version", "2022-11-28")
+                    .build();
+
+            RestClient.RequestHeadersSpec<?> request = client.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/users/{username}/events/public")
+                            .queryParam("per_page", perPage)
+                            .build(username));
+
+            if (githubApiToken != null && !githubApiToken.isBlank()) {
+                request.headers(headers -> headers.setBearerAuth(githubApiToken));
+            }
+
+            JsonNode events = request.retrieve().body(JsonNode.class);
+            if (events == null || !events.isArray()) {
+                return List.of();
+            }
+
+            List<GithubActivityResponse> responses = new ArrayList<>();
+            events.forEach(event -> responses.add(toResponse(event)));
+
+            return responses;
+        } catch (RestClientResponseException exception) {
+            return List.of();
+        } catch (RestClientException exception) {
+            return List.of();
+        }
+    }
+
+    private GithubActivityResponse toResponse(JsonNode event) {
+        String githubType = event.path("type").asText("Event");
+        String repository = event.path("repo").path("name").asText("-");
+        String actor = event.path("actor").path("login").asText("");
+        String createdAt = event.path("created_at").asText("");
+
+        return GithubActivityResponse.builder()
+                .id(event.path("id").asText())
+                .type(mapType(githubType))
+                .title(buildTitle(githubType, event))
+                .repository(repository)
+                .description(buildDescription(githubType, event))
+                .timeLabel(buildTimeLabel(createdAt))
+                .url(buildUrl(repository, actor))
+                .actor(actor)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    private String mapType(String githubType) {
+        return switch (githubType) {
+            case "PushEvent" -> "commit";
+            case "PullRequestEvent" -> "pull-request";
+            case "ReleaseEvent" -> "release";
+            default -> "note";
+        };
+    }
+
+    private String buildTitle(String githubType, JsonNode event) {
+        JsonNode payload = event.path("payload");
+
+        return switch (githubType) {
+            case "PushEvent" -> buildPushTitle(payload);
+            case "PullRequestEvent" -> {
+                String action = payload.path("action").asText("updated");
+                String title = payload.path("pull_request").path("title").asText("Pull request");
+                yield action + ": " + title;
+            }
+            case "ReleaseEvent" -> "Release " + payload.path("release").path("tag_name").asText("");
+            case "IssuesEvent" -> "Issue " + payload.path("issue").path("title").asText("");
+            case "CreateEvent" -> "Created " + payload.path("ref_type").asText("resource");
+            case "ForkEvent" -> "Forked repository";
+            case "WatchEvent" -> "Starred repository";
+            default -> githubType;
+        };
+    }
+
+    private String buildPushTitle(JsonNode payload) {
+        JsonNode commits = payload.path("commits");
+        if (commits.isArray() && !commits.isEmpty()) {
+            return commits.get(0).path("message").asText("Push");
+        }
+
+        return "Push";
+    }
+
+    private String buildDescription(String githubType, JsonNode event) {
+        JsonNode payload = event.path("payload");
+        String repository = event.path("repo").path("name").asText("-");
+
+        return switch (githubType) {
+            case "PushEvent" -> {
+                int count = payload.path("commits").isArray() ? payload.path("commits").size() : 0;
+                yield count + " commits pushed to " + repository;
+            }
+            case "PullRequestEvent" -> payload.path("pull_request").path("html_url").asText(repository);
+            case "ReleaseEvent" -> payload.path("release").path("html_url").asText(repository);
+            default -> repository;
+        };
+    }
+
+    private String buildTimeLabel(String createdAt) {
+        if (createdAt == null || createdAt.isBlank()) {
+            return "GitHub";
+        }
+
+        try {
+            Instant created = Instant.parse(createdAt);
+            long days = Duration.between(created, Instant.now()).toDays();
+
+            if (days == 0) {
+                return "\uC624\uB298";
+            }
+            if (days == 1) {
+                return "\uC5B4\uC81C";
+            }
+            return days + "\uC77C \uC804";
+        } catch (RuntimeException exception) {
+            return createdAt;
+        }
+    }
+
+    private String buildUrl(String repository, String actor) {
+        if (!repository.isBlank() && !repository.equals("-")) {
+            return "https://github.com/" + repository;
+        }
+
+        return "https://github.com/" + actor;
+    }
+
+    private record CachedActivity(List<GithubActivityResponse> responses, Instant cachedAt) {
+
+        private boolean isFresh() {
+            return cachedAt.plus(CACHE_TTL).isAfter(Instant.now());
+        }
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/api/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/example/coalawebbackend/api/user/dto/UserCreateRequest.java
@@ -26,8 +26,11 @@ public class UserCreateRequest {
 
     @NotBlank
     @Email
+    @Pattern(
+            regexp = "^[A-Za-z0-9._%+-]+@jbnu\\.ac\\.kr$",
+            message = "전북대학교 이메일(@jbnu.ac.kr)만 사용할 수 있습니다.")
     @Size(max = 100)
-    @Schema(example = "user@example.com")
+    @Schema(example = "user@jbnu.ac.kr")
     private String email;
 
     @NotBlank
@@ -88,7 +91,7 @@ public class UserCreateRequest {
 
     public User toEntity() {
         return User.builder()
-                .email(email)
+                .email(normalizeEmail())
                 .password(password)
                 .name(name)
                 .nickname(nickname)
@@ -107,6 +110,10 @@ public class UserCreateRequest {
         return department == null || department.isBlank()
                 ? "미입력"
                 : department.trim();
+    }
+
+    private String normalizeEmail() {
+        return email.trim().toLowerCase();
     }
 
     private String normalizeOptional(String value) {

--- a/src/main/java/com/example/coalawebbackend/common/config/DevAccountConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/DevAccountConfig.java
@@ -1,0 +1,54 @@
+package com.example.coalawebbackend.common.config;
+
+import com.example.coalawebbackend.domain.user.entity.AcademicStatus;
+import com.example.coalawebbackend.domain.user.entity.Gender;
+import com.example.coalawebbackend.domain.user.entity.User;
+import com.example.coalawebbackend.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@Profile("!prod")
+@RequiredArgsConstructor
+public class DevAccountConfig {
+
+    private static final String DEV_LOGIN_ID = "test";
+    private static final String DEV_PASSWORD = "test1234";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.seed.dev-account.enabled:true}")
+    private boolean enabled;
+
+    @Bean
+    public ApplicationRunner devAccountRunner() {
+        return args -> {
+            if (!enabled || userRepository.existsByEmail(DEV_LOGIN_ID)) {
+                return;
+            }
+
+            User devUser = User.builder()
+                    .email(DEV_LOGIN_ID)
+                    .password(passwordEncoder.encode(DEV_PASSWORD))
+                    .name("코알라")
+                    .nickname("coala-test")
+                    .birthDate(LocalDate.of(2000, 1, 1))
+                    .gender(Gender.PREFER_NOT_TO_SAY)
+                    .department("컴퓨터인공지능학부")
+                    .studentId("20180000")
+                    .grade(4)
+                    .githubId("coala-test")
+                    .academicStatus(AcademicStatus.ENROLLED)
+                    .build();
+
+            userRepository.save(devUser);
+        };
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/common/config/DevAccountConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/DevAccountConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 public class DevAccountConfig {
 
-    private static final String DEV_LOGIN_ID = "test";
+    private static final String DEV_EMAIL = "test@test.com";
     private static final String DEV_PASSWORD = "test1234";
 
     private final UserRepository userRepository;
@@ -30,21 +30,21 @@ public class DevAccountConfig {
     @Bean
     public ApplicationRunner devAccountRunner() {
         return args -> {
-            if (!enabled || userRepository.existsByEmail(DEV_LOGIN_ID)) {
+            if (!enabled || userRepository.existsByEmail(DEV_EMAIL)) {
                 return;
             }
 
             User devUser = User.builder()
-                    .email(DEV_LOGIN_ID)
+                    .email(DEV_EMAIL)
                     .password(passwordEncoder.encode(DEV_PASSWORD))
                     .name("코알라")
-                    .nickname("coala-test")
+                    .nickname("coala-test-2018")
                     .birthDate(LocalDate.of(2000, 1, 1))
                     .gender(Gender.PREFER_NOT_TO_SAY)
                     .department("컴퓨터인공지능학부")
-                    .studentId("20180000")
+                    .studentId("20180001")
                     .grade(4)
-                    .githubId("coala-test")
+                    .githubId("coala-test-2018")
                     .academicStatus(AcademicStatus.ENROLLED)
                     .build();
 

--- a/src/main/java/com/example/coalawebbackend/common/config/RestClientConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.example.coalawebbackend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                     "/api/boards/*",
                                     "/api/boards/*/posts",
                                     "/api/boards/*/posts/*",
+                                    "/api/github/public-activity",
                                     "/api/posts/*/comments",
                                     "/api/posts/*/resources"
                             ).permitAll()

--- a/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/coalawebbackend/common/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -30,7 +31,7 @@ public class SecurityConfig {
     @Value("${app.cors.allowed-origins:http://localhost:3000,http://127.0.0.1:3000}")
     private String allowedOrigins;
 
-    @Value("${app.security.swagger-enabled:true}")
+    @Value("${app.security.swagger-enabled:false}")
     private boolean swaggerEnabled;
 
     @Bean
@@ -38,6 +39,7 @@ public class SecurityConfig {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> {
                     auth
                             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
@@ -77,8 +79,9 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         configuration.setAllowedOrigins(parseAllowedOrigins());
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -26,3 +26,6 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   security:
     swagger-enabled: false
+  seed:
+    dev-account:
+      enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,3 +32,8 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://127.0.0.1:3000}
   security:
     swagger-enabled: ${SWAGGER_ENABLED:true}
+
+github:
+  api:
+    base-url: ${GITHUB_API_BASE_URL:https://api.github.com}
+    token: ${GITHUB_API_TOKEN:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,9 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://127.0.0.1:3000}
   security:
     swagger-enabled: ${SWAGGER_ENABLED:false}
+  seed:
+    dev-account:
+      enabled: ${APP_SEED_DEV_ACCOUNT_ENABLED:true}
 
 github:
   api:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://127.0.0.1:3000}
   security:
-    swagger-enabled: ${SWAGGER_ENABLED:true}
+    swagger-enabled: ${SWAGGER_ENABLED:false}
 
 github:
   api:

--- a/src/test/java/com/example/coalawebbackend/CoalaWebBackendApplicationTests.java
+++ b/src/test/java/com/example/coalawebbackend/CoalaWebBackendApplicationTests.java
@@ -2,8 +2,18 @@ package com.example.coalawebbackend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:coala-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "jwt.secret=test-jwt-secret-for-context-loads",
+        "app.security.swagger-enabled=false"
+})
 class CoalaWebBackendApplicationTests {
 
     @Test


### PR DESCRIPTION
배포 전 수정함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* GitHub 공개 활동 조회 엔드포인트 추가: 사용자의 공개 GitHub 이벤트를 검색할 수 있습니다
* 단일 보드 조회 엔드포인트 추가: 보드 ID로 개별 보드의 상세 정보를 조회할 수 있습니다

**개선사항**
* 로그인 필드 유효성 검사 강화
* CORS 및 세션 관리 보안 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->